### PR TITLE
contextualPageData

### DIFF
--- a/src/lib/modules/content-editor/content-editor-editor-context.ts
+++ b/src/lib/modules/content-editor/content-editor-editor-context.ts
@@ -12,6 +12,7 @@ export type EditorContextType = {
   previewing: boolean;
   streams: StreamContextType;
   renderFlags: PageEditorRenderFlags;
+  contextualPageData?: any;
 };
 export const EditorContext = createContext<EditorContextType>(null);
 

--- a/src/lib/modules/page-editor/page-editor-app.tsx
+++ b/src/lib/modules/page-editor/page-editor-app.tsx
@@ -42,7 +42,8 @@ export default class PageEditorApp {
       individualComponents: false,
       noRearrange: false,
       noAdd: false,
-    }
+    },
+    contextualPageData
   ) {
     if (newComponentList) {
       this.components = newComponentList;
@@ -71,6 +72,7 @@ export default class PageEditorApp {
             exportState={(setState) => {
               this._externalSetState = setState;
             }}
+            contextualPageData={contextualPageData}
           />
         </div>
       );

--- a/src/lib/modules/page-editor/page-editor.tsx
+++ b/src/lib/modules/page-editor/page-editor.tsx
@@ -32,6 +32,7 @@ export type PageEditorPropType = {
   pageMeta: any;
   renderFlags: PageEditorRenderFlags;
   exportState: (setState: Function) => void;
+  contextualPageData: any;
 };
 
 export class PageEditor extends React.Component<
@@ -205,6 +206,7 @@ export class PageEditor extends React.Component<
             previewing: preview,
             renderFlags,
             streams: streams,
+            contextualPageData: this.props.contextualPageData,
           }}>
           <ContentSection isRoot />
           <StreamDriverComponent />


### PR DESCRIPTION
Contextual Page Data can be passed into initialize app and is made available in the `EditorContext` this allows for contextual data to be passed down to user components from the environment in which the page editor is initialized